### PR TITLE
Replace Docker with Podman for artifact processing

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -43,7 +43,7 @@ fi
 echo "--- :junit: Building the failures file"
 
 if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUN_IN_DOCKER:-true}" =~ "true" ]]; then
-  docker \
+  podman \
     --log-level "error" \
     run \
       --rm \
@@ -63,7 +63,7 @@ echo "--- :junit: Processing the junits"
 
 set +e
 if [[ "${BUILDKITE_PLUGIN_JUNIT_ANNOTATE_RUN_IN_DOCKER:-true}" =~ "true" ]]; then
-  docker \
+  podman \
     --log-level "error" \
     run \
       --rm \


### PR DESCRIPTION
Support `containerd` Container Engine for containers running in AWS EKS.

Fixes the following error
```
docker: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?.
See 'docker run --help'.
🚨 Error: The command exited with status 125
```

